### PR TITLE
Added support for 4.5.0 and auto install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ brew install raylib
 
 ## Instalation of Xcode project template
 
+### Manual installation
 Create folder, preferably in user's local library:
 
 ```
@@ -25,3 +26,14 @@ mkdir -p ~/Library/Developer/Xcode/Templates/Project\ Templates/Raylib/Raylib.xc
 Copy all files fom this repo into this folder.
 
 From now on, when creating new project, it's possible to select raylib (in macOS platform, scroll down to see it at the bottom of the list). Such created new project will have a link to `libraylib.a` and pre-set search paths to headers and library files. Additionally, it will disable library validations, preventing linking the unsigned raylib.
+
+### Scripted installation
+
+Too lazy to manually install the template? Copy and paste these lines into your terminal and let your computer take care of everything!
+```
+mkdir -p ~/Library/Developer/Xcode/Templates/Project\ Templates/Raylib/Raylib.xctemplate/
+cd ~/Library/Developer/Xcode/Templates/Project\ Templates/Raylib/Raylib.xctemplate/
+wget https://github.com/acejacek/raylib_xcode/archive/main.zip
+unzip -j raylib_xcode-main.zip
+rm https://github.com/acejacek/raylib_xcode/archive/main.zip
+```

--- a/TemplateInfo.plist
+++ b/TemplateInfo.plist
@@ -44,7 +44,7 @@
 			<key>PathType</key>
 			<string>Absolute</string>
 			<key>Path</key>
-			<string>/usr/local/Cellar/raylib/4.2.0/lib/libraylib.a</string>
+			<string>/usr/local/Cellar/raylib/4.5.0/lib/libraylib.a</string>
 		</dict>
 		<key>main.c</key>
 		<dict>
@@ -62,9 +62,9 @@
 		<key>SharedSettings</key>
 		<dict>
 			<key>LIBRARY_SEARCH_PATHS</key>
-			<string>$(inherited) /usr/local/Cellar/raylib/4.2.0/lib</string>
+			<string>$(inherited) /usr/local/Cellar/raylib/4.5.0/lib</string>
 			<key>HEADER_SEARCH_PATHS</key>
-			<string>/usr/local/Cellar/raylib/4.2.0/**</string>
+			<string>/usr/local/Cellar/raylib/4.5.0/**</string>
 			<key>CODE_SIGN_ENTITLEMENTS</key>
 			<string>___PACKAGENAME___/raylib.entitlements</string>
 		</dict>


### PR DESCRIPTION
The template file has been modified in order to support the new version 4.5.0 of the Raylib library.
A section has been added to the Readme.md where commands have been written to allow the terminal to automatically install the theme.

-Cheers